### PR TITLE
Fix font size and add line height

### DIFF
--- a/Sources/CodeViewer/CodeViewer.swift
+++ b/Sources/CodeViewer/CodeViewer.swift
@@ -21,6 +21,7 @@ public struct CodeViewer: ViewRepresentable {
     private let lightTheme: CodeWebView.Theme
     private let isReadOnly: Bool
     private let fontSize: Int
+    private let lineHeight: Float
     
     public init(
         content: Binding<String>,
@@ -29,6 +30,7 @@ public struct CodeViewer: ViewRepresentable {
         lightTheme: CodeWebView.Theme = .solarized_light,
         isReadOnly: Bool = false,
         fontSize: Int = 12,
+        lineHeight: Float = 1.3,
         textDidChanged: ((String) -> Void)? = nil
     ) {
         self._content = content
@@ -37,6 +39,7 @@ public struct CodeViewer: ViewRepresentable {
         self.lightTheme = lightTheme
         self.isReadOnly = isReadOnly
         self.fontSize = fontSize
+        self.lineHeight = lineHeight
         self.textDidChanged = textDidChanged
     }
     
@@ -50,6 +53,7 @@ public struct CodeViewer: ViewRepresentable {
         codeView.setReadOnly(isReadOnly)
         codeView.setMode(mode)
         codeView.setFontSize(fontSize)
+        codeView.setLineHeight(lineHeight)
         
         codeView.setContent(content)
         codeView.clearSelection()

--- a/Sources/CodeViewer/CodeWebView.swift
+++ b/Sources/CodeViewer/CodeWebView.swift
@@ -333,7 +333,7 @@ public class CodeWebView: CustomView {
     }
     
     func setLineHeight(_ lineHeight: Float) {
-        let script = "document.getElementById('editor').style.line-height='\(lineHeight)';"
+        let script = "document.getElementById('editor').style.lineHeight='\(lineHeight)';"
         callJavascript(javascriptString: script)
     }
     

--- a/Sources/CodeViewer/CodeWebView.swift
+++ b/Sources/CodeViewer/CodeWebView.swift
@@ -332,6 +332,11 @@ public class CodeWebView: CustomView {
         callJavascript(javascriptString: script)
     }
     
+    func setLineHeight(_ lineHeight: Float) {
+        let script = "document.getElementById('editor').style.line-height='\(lineHeight)';"
+        callJavascript(javascriptString: script)
+    }
+    
     func clearSelection() {
         let script = "editor.clearSelection();"
         callJavascript(javascriptString: script)

--- a/Sources/CodeViewer/Resources/ace.bundle/index.html
+++ b/Sources/CodeViewer/Resources/ace.bundle/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Set viewport. -->
+<meta name="viewport" content="initial-scale=1">
 <title>ACE in Action</title>
 <style type="text/css" media="screen">
     #editor {


### PR DESCRIPTION
#### What's this PR do?

- [x] Fix font size by set viewport, that means we set point as font size. 
- [x] Add line height, then we can calculate the code viewer's total height.

Here is an example, how set `CodeViewer` height:
```swift
   CodeViewer(content: .constant(code), mode: CodeWebView.Mode(rawValue: configuration.language ?? "") ?? .text, darkTheme: .tomorrow_night_eighties, lightTheme: .tomorrow, isReadOnly: true, fontSize: 14, lineHeight: 1.3)
          .frame(height: CGFloat(code.components(separatedBy: .newlines).count) * 14 * 1.3)
```

